### PR TITLE
Stop HTML from being escaped for property values and names

### DIFF
--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.8-bit.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.8-bit.hbs
@@ -44,7 +44,7 @@
         <rect x="0" y="0" height="100%" width="100%" stroke="none" fill="url(#pattern)">
       </svg>      
     </div>
-    <div id="token-name" class="token-name">{{name}}</div>
+    <div id="token-name" class="token-name">{{{name}}}</div>
     <div id="token-type" class="token-type">{{tokenType}}</div>
   </div>
   {{#if properties~}}
@@ -61,7 +61,7 @@
         </div>
         <div class="property-value-container">
         <div class="property-value">
-          {{~this.value~}}
+            {{{~this.value~}}}
         </div>
         </div>
       </div>

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.glass.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.glass.hbs
@@ -28,7 +28,7 @@
   </div>
     <div id="token-names-container" class="box token-names-container">
     <div id="token-names" class="token-names">
-      <div id="name" class="name">{{name}}</div>
+      <div id="name" class="name">{{{name}}}</div>
       {{~#if gmName}}
       <div id="name-gm" class="name-gm gm-only">{{gmName}}</div>
       {{~/if}}
@@ -52,7 +52,7 @@
           </div>
           <div class="property-value-container">
           <div class="property-value">
-            {{~this.value~}}
+              {{{~this.value~}}}
           </div>
           </div>
         </div>

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.metal.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.metal.hbs
@@ -31,7 +31,7 @@
       />
     </div> 
     <div id="name-container" class="name-container">
-      <div id="token-name" class="token-name">{{name}}</div>
+      <div id="token-name" class="token-name">{{{name}}}</div>
     </div>  
     <div id="token-type" class="token-type">{{tokenType}}</div>
     {{#if properties~}}
@@ -48,7 +48,7 @@
           </div>
           <div class="property-value-container">
           <div class="property-value">
-            {{~this.value~}}
+              {{{~this.value~}}}
           </div>
           </div>
         </div>

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.notes.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.notes.hbs
@@ -29,7 +29,7 @@
   <div id="token-names-container" class="token-names-container">
     <div class="token-name-container name-container">
       <div class="name-container-label">Name:</div>
-      <div class="name-container-value">{{name}}</div>
+      <div class="name-container-value">{{{name}}}</div>
     </div>  
     {{~#if gmName}}
     <div class="gm-name-container name-container gm-only">

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.parchment.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.parchment.hbs
@@ -17,7 +17,7 @@
 </head>
 <body>
 <div id="statsheet" class="{{statSheetLocation}} statsheet {{#if gm}}gm{{else}}player{{/if}} {{tokenType}}">
-  <div class="token-name" id="token-name">{{name}}</div>
+  <div class="token-name" id="token-name">{{{name}}}</div>
     <svg id="portrait-frame" class="portrait-frame" 
         viewBox="0 0 500 500" preserveAspectRatio="xMidYMid" 
         xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" >
@@ -87,7 +87,7 @@
         </div>
         <div class="property-value-container">
         <div class="property-value">
-          {{~this.value~}}
+            {{{~this.value~}}}
         </div>
         </div>
       </div>

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.trippy.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.trippy.hbs
@@ -27,7 +27,7 @@
       />
     </div>
     <div id="token-names" class="token-names">
-      <div id="name" class="name">{{name}}</div>
+      <div id="name" class="name">{{{name}}}</div>
       {{~#if gmName}}
       <div id="name-gm" class="name-gm gm-only">{{gmName}}</div>
       {{~/if}}
@@ -52,7 +52,7 @@
           </div>
           <div class="property-value-container">
           <div class="property-value">
-            {{~this.value~}}
+            {{{~this.value~}}}
           </div>
           </div>
         </div>

--- a/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.vanilla.hbs
+++ b/libraries/stat-sheets/rev-stat-sheets/library/public/sheets/rev.vanilla.hbs
@@ -25,7 +25,7 @@
     />
   </div>
   <div id="token-names" class="token-names">
-    <div id="name" class="name">{{name}}</div>
+    <div id="name" class="name">{{{name}}}</div>
     {{~#if gmName}}
     <div id="name-gm" class="name-gm gm-only">{{gmName}}</div>
     {{~/if}}
@@ -45,7 +45,7 @@
               </div>
               <div class="property-value-container">
               <div class="property-value">
-                {{~this.value~}}
+                  {{{~this.value~}}}
               </div>
               </div>
             </div>


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #6


### Description of the Change
Changed double handlebars to triple for names and property values

### Possible Drawbacks
People might have wanted it the old way

### Documentation Notes
HTML no longer escaped in token name and property values on built-in stat-sheets by Rev

### Release Notes
n/a